### PR TITLE
Fix room/index

### DIFF
--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -10,6 +10,7 @@
 		      <%= another_entry.user.name %>
 		  	</div>
 		  	<div class="col-7">
+		  	  <span><%= another_entry.room.messages.last.body %></span>
 		  	</div>
 		  	<div class="col-2">
 		  	  <% unless current_user.room_message_count(another_entry.room) == 0 %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -10,7 +10,9 @@
 		      <%= another_entry.user.name %>
 		  	</div>
 		  	<div class="col-7">
-		  	  <span><%= another_entry.room.messages.last.body %></span>
+		  		<% unless another_entry.room.messages.empty? %>
+		  	    <span><%= another_entry.room.messages.last.body %></span>
+		  	  <% end %>
 		  	</div>
 		  	<div class="col-2">
 		  	  <% unless current_user.room_message_count(another_entry.room) == 0 %>


### PR DESCRIPTION
dm画面を開いた後、メッセージを送らずに閉じるとルーム一覧画面でエラーになる問題を修正